### PR TITLE
Rename load/save functions to read/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ pip install mondaytoframe
 Here's a basic example of how to use the package using a token string:
 
 ```python
-from mondaytoframe import load, save
+from mondaytoframe import read, save
 
 monday_token = "your_monday_token"
 
-# Load your board to a dataframe... 
-df = load("your_board_id", monday_token)
+# Read your board as a dataframe... 
+df = read("your_board_id", monday_token)
 
 # ... perform data transformation on your dataframe
 df_transformed = df.copy()
@@ -33,10 +33,10 @@ save("you_board_id", df_transformed, monday_token)
 Alternatively, you can set `MONDAYTOFRAME_TOKEN` environment variable:
 
 ```python
-from mondaytoframe import load, save
+from mondaytoframe import read, save
 
-# Load your board to a dataframe... 
-df = load("your_board_id")
+# Read your board as a dataframe... 
+df = read("your_board_id")
 
 # ... perform data transformation on your dataframe
 df_transformed = df.copy()
@@ -55,7 +55,7 @@ save("you_board_id", df_transformed)
 
 ### Supported Data Types
 
-| Column Type            | Supported by `load` | Supported by `save` |
+| Column Type            | Supported by `read` | Supported by `save` |
 |------------------------|---------------------|---------------------|
 | Item ID                | ✅                  | ✅                  |
 | Name                   | ✅                  | ✅                  |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install mondaytoframe
 Here's a basic example of how to use the package using a token string:
 
 ```python
-from mondaytoframe import read, save
+from mondaytoframe import read, update
 
 monday_token = "your_monday_token"
 
@@ -26,14 +26,14 @@ df = read("your_board_id", monday_token)
 df_transformed = df.copy()
 
 # ... and store the results in Monday again!
-save("you_board_id", df_transformed, monday_token)
+update("you_board_id", df_transformed, monday_token)
 
 ```
 
 Alternatively, you can set `MONDAYTOFRAME_TOKEN` environment variable:
 
 ```python
-from mondaytoframe import read, save
+from mondaytoframe import read, update
 
 # Read your board as a dataframe... 
 df = read("your_board_id")
@@ -42,7 +42,7 @@ df = read("your_board_id")
 df_transformed = df.copy()
 
 # ... and store the results in Monday again!
-save("you_board_id", df_transformed)
+update("you_board_id", df_transformed)
 
 ```
 
@@ -55,7 +55,7 @@ save("you_board_id", df_transformed)
 
 ### Supported Data Types
 
-| Column Type            | Supported by `read` | Supported by `save` |
+| Column Type            | Supported by `read` | Supported by `update` |
 |------------------------|---------------------|---------------------|
 | Item ID                | ✅                  | ✅                  |
 | Name                   | ✅                  | ✅                  |

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # Api reference
 
-::: mondaytoframe.load
+::: mondaytoframe.read
     options:
       show_root_heading: true
       show_source: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,7 @@
     options:
       show_root_heading: true
       show_source: true
-::: mondaytoframe.save
+::: mondaytoframe.update
     options:
       show_root_heading: true
       show_source: true

--- a/src/mondaytoframe/__init__.py
+++ b/src/mondaytoframe/__init__.py
@@ -1,3 +1,3 @@
-from .io import load, save
+from .io import read, save
 
-__all__ = ["load", "save"]
+__all__ = ["read", "save"]

--- a/src/mondaytoframe/__init__.py
+++ b/src/mondaytoframe/__init__.py
@@ -1,3 +1,3 @@
-from .io import read, save
+from .io import read, update
 
-__all__ = ["read", "save"]
+__all__ = ["read", "update"]

--- a/src/mondaytoframe/io.py
+++ b/src/mondaytoframe/io.py
@@ -41,17 +41,17 @@ def _create_or_get_tag(monday: MondayClient, tag_name: str):
 @validate_call(
     config=ConfigDict(arbitrary_types_allowed=True, coerce_numbers_to_str=True)
 )
-def load(
+def read(
     board_id: str,
     monday_token: TokenType,
     unknown_type: Literal["text", "drop", "raise"] = "text",
     **kwargs: Any,
 ):
     """
-    Load data from a Monday.com board into a pandas DataFrame.
+    Read data from a Monday.com board into a pandas DataFrame.
 
     Arguments:
-        board_id (str): The ID of the Monday.com board to load data from.
+        board_id (str): The ID of the Monday.com board to read data from.
         monday_token (TokenType): The authentication token for Monday.com API.
         unknown_type (Literal["text", "drop", "raise"]): Specifies how to handle unknown column types.
             - "text": Use a default text parser for unknown column types (default).
@@ -73,9 +73,9 @@ def load(
     Usage:
 
     ```python
-    from mondaytoframe import load
+    from mondaytoframe import read
 
-    df = load(board_id="123456", monday_token="your_token")
+    df = read(board_id="123456", monday_token="your_token")
     print(df.head())
     ```
     """
@@ -102,7 +102,7 @@ def load(
                 )
             case "drop":
                 msg = (
-                    f"Unknown column types found in the board: {cols_without_parsers}. Not loading them."
+                    f"Unknown column types found in the board: {cols_without_parsers}. Not reading them."
                     "Set unknown_type='text' to try to get them using a default text parser."
                 )
                 logger.warning(msg)

--- a/src/mondaytoframe/io.py
+++ b/src/mondaytoframe/io.py
@@ -154,7 +154,7 @@ def read(
 @validate_call(
     config=ConfigDict(arbitrary_types_allowed=True, coerce_numbers_to_str=True)
 )
-def save(
+def update(
     board_id: str,
     df: pd.DataFrame,
     monday_token: TokenType,
@@ -162,11 +162,11 @@ def save(
     **kwargs: Any,
 ):
     """
-    Save a pandas DataFrame to a Monday.com board.
+    Update a pandas DataFrame to a Monday.com board.
 
     Arguments:
         board_id (str): The ID of the Monday.com board.
-        df (pd.DataFrame): The DataFrame to save to the board.
+        df (pd.DataFrame): The DataFrame to update to the board.
         monday_token (TokenType): The authentication token for Monday.com.
         unknown_type (Literal["drop", "raise"]): Specifies how to handle columns in the DataFrame that do not have a corresponding parser in the board schema.
             - "drop": Ignore columns that do not have a corresponding parser (default).
@@ -179,7 +179,7 @@ def save(
     Usage:
 
     ```python
-    from mondaytoframe import save
+    from mondaytoframe import update
     import pandas as pd
 
     df = pd.DataFrame({
@@ -187,7 +187,7 @@ def save(
         "Status": ["Done", "In Progress"],
         "Tags": [["tag1"], ["tag2", "tag3"]],
     })
-    save(board_id="123456", df=df, monday_token="your_token")
+    update(board_id="123456", df=df, monday_token="your_token")
     ```
     """
 
@@ -216,7 +216,7 @@ def save(
             case "raise":
                 raise ValueError(
                     f"Unknown column types found in the board: {cols_without_parsers}."
-                    "Set unknown_type='drop' to ignore this error and save all other columns."
+                    "Set unknown_type='drop' to ignore this error and update all other columns."
                 )
             case "drop":
                 msg = f"Unknown column types found in the board: {cols_without_parsers}. Not saving them."

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,7 +3,7 @@ from typing import Any
 from monday import MondayClient
 import pytest
 import pandas as pd
-from mondaytoframe import read, save
+from mondaytoframe import read, update
 from mondaytoframe.io import TokenType
 from mondaytoframe.model import BoardKind
 from monday.resources.types import ColumnType
@@ -59,7 +59,7 @@ def test_read_board_as_frame(
     )
 
 
-def test_save_calls_monday_api(
+def test_update_calls_monday_api(
     mocker,
     dataframe_representation,
     response_fetch_boards_by_id,
@@ -69,7 +69,7 @@ def test_save_calls_monday_api(
         response_fetch_boards_by_id
     )
 
-    save("board_123", dataframe_representation, "fake_token", unknown_type="drop")
+    update("board_123", dataframe_representation, "fake_token", unknown_type="drop")
 
     # Ensure the Monday API was called for each item
     assert mock_monday_client().items.change_multiple_column_values.call_count == len(
@@ -97,10 +97,10 @@ def _check_queries_were_valid(mock_monday_client):
         assert not validate(schema, parsed_query), f"Error in query {query}"
 
 
-def test_save_empty_dataframe(mocker, dataframe_representation):
+def test_update_empty_dataframe(mocker, dataframe_representation):
     mock_monday_client = mocker.patch("monday.MondayClient")
     empty_df = dataframe_representation.iloc[0:0, :]
-    save("board_123", empty_df, "fake_token")
+    update("board_123", empty_df, "fake_token")
     mock_monday_client().items.change_multiple_column_values.assert_not_called()
 
 
@@ -171,8 +171,8 @@ def test_integration_with_monday_api(
         .assign(Group="Group Title")
     )
 
-    # Save the adjusted dataframe to the board and verify everything is still the same
-    save(
+    # Update the adjusted dataframe to the board and verify everything is still the same
+    update(
         board_id,
         adjusted_df,
         monday_token,
@@ -189,7 +189,7 @@ def test_integration_with_monday_api(
 
     # Switch the content of the rows (not the index) and do a round trip again to test emptying
     switched_rows_df = first_result.iloc[::-1].set_index(first_result.index)
-    save(
+    update(
         board_id,
         switched_rows_df,
         monday_token,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,7 +3,7 @@ from typing import Any
 from monday import MondayClient
 import pytest
 import pandas as pd
-from mondaytoframe import load, save
+from mondaytoframe import read, save
 from mondaytoframe.io import TokenType
 from mondaytoframe.model import BoardKind
 from monday.resources.types import ColumnType
@@ -34,7 +34,7 @@ def schema():
     return build_schema(response.text)
 
 
-def test_load_board_as_frame(
+def test_read_board_as_frame(
     mocker,
     response_fetch_boards_by_id: dict[str, Any],
     response_fetch_items_by_board_id: dict[str, Any],
@@ -48,7 +48,7 @@ def test_load_board_as_frame(
         response_fetch_items_by_board_id
     )
 
-    result = load("board_123", "fake_token", unknown_type="drop")
+    result = read("board_123", "fake_token", unknown_type="drop")
 
     _check_queries_were_valid(mock_monday_client)
     pd.testing.assert_frame_equal(
@@ -160,7 +160,7 @@ def test_integration_with_monday_api(
     board_id = board_for_test
 
     # Load (empty) board
-    df = load(board_id, monday_token)
+    df = read(board_id, monday_token)
 
     # Some of the monday-defined ID's must come from the API, such as item and user id's
     users = monday_client.users.fetch_users()
@@ -179,7 +179,7 @@ def test_integration_with_monday_api(
         unknown_type="drop",
         create_labels_if_missing=True,
     )
-    first_result = load(board_id, monday_token, unknown_type="drop", limit=1)
+    first_result = read(board_id, monday_token, unknown_type="drop", limit=1)
     pd.testing.assert_frame_equal(
         adjusted_df.drop(columns=NON_SUPPORTED_COLUMNS),
         first_result,
@@ -196,7 +196,7 @@ def test_integration_with_monday_api(
         unknown_type="raise",
         create_labels_if_missing=True,
     )
-    second_result = load(board_id, monday_token)
+    second_result = read(board_id, monday_token)
     pd.testing.assert_frame_equal(
         switched_rows_df, second_result, check_column_type=False, check_like=True
     )


### PR DESCRIPTION
Rename the `load` and `save` functions to `read` and `update` respectively for improved clarity and consistency in the API. Update all references and documentation accordingly.